### PR TITLE
Actually run at 60fps

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,10 +20,10 @@ window.onload = function onLoad() {
 
   line.animate(progress());  // Number from 0.0 to 1.0
 
-  setInterval(update, 16);
+  requestAnimationFrame(update);
 
   function update() {
     line.set(progress());
+    requestAnimationFrame(update);
   }
-
 };


### PR DESCRIPTION
Using `setInterval()` with a 16ms interval won't actually cause the progress bar to animate at 60fps. If you collect a profile using Chrome DevTools you'll notice that it misses a lot of frames as the interval gets out of sync with the display refresh. Using `requestAnimationFrame()` instead causes the browser to update the current progress immediately before rendering the next frame, making it update at whatever rate the system is running at.